### PR TITLE
Added FileProvider support

### DIFF
--- a/ihg/src/main/AndroidManifest.xml
+++ b/ihg/src/main/AndroidManifest.xml
@@ -78,5 +78,17 @@
             android:label="Wybierz drukarkę"
             android:screenOrientation="portrait">
         </activity>
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="com.ihg.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+
+        </provider>
     </application>
 </manifest>

--- a/ihg/src/main/java/com/wruzjan/ihg/EnterData2Activity.java
+++ b/ihg/src/main/java/com/wruzjan/ihg/EnterData2Activity.java
@@ -39,6 +39,8 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
+import androidx.core.content.FileProvider;
+
 public class EnterData2Activity extends Activity {
 
     private AddressDataSource addressDataSource;
@@ -1659,7 +1661,7 @@ public class EnterData2Activity extends Activity {
     }
 
     public void sendMail(View view) {
-        Uri uri = Uri.fromFile(new File(pdfFilePath));
+        Uri uri = FileProvider.getUriForFile(this, "com.ihg.fileprovider", new File(pdfFilePath));
 
         Intent i = new Intent(Intent.ACTION_SEND);
         i.setType("message/rfc822");
@@ -1686,7 +1688,7 @@ public class EnterData2Activity extends Activity {
     }
 
     public void dropbox(View view) {
-        Uri uri = Uri.fromFile(new File(pdfFilePath));
+        Uri uri = FileProvider.getUriForFile(this, "com.ihg.fileprovider", new File(pdfFilePath));
 
         Intent intent = new Intent(Intent.ACTION_SEND);
         intent.setType("text/plain");

--- a/ihg/src/main/java/com/wruzjan/ihg/EnterDataActivity.java
+++ b/ihg/src/main/java/com/wruzjan/ihg/EnterDataActivity.java
@@ -47,6 +47,7 @@ import java.util.Date;
 import java.util.Locale;
 
 import androidx.annotation.NonNull;
+import androidx.core.content.FileProvider;
 
 public class EnterDataActivity extends Activity {
 
@@ -803,7 +804,7 @@ public class EnterDataActivity extends Activity {
     }
 
     public void sendMail(View view) {
-        Uri uri = Uri.fromFile(new File(pdfFilePath));
+        Uri uri = FileProvider.getUriForFile(this, "com.ihg.fileprovider", new File(pdfFilePath));
 
         Intent i = new Intent(Intent.ACTION_SEND);
         i.setType("message/rfc822");
@@ -830,7 +831,7 @@ public class EnterDataActivity extends Activity {
     }
 
     public void dropbox(View view) {
-        Uri uri = Uri.fromFile(new File(pdfFilePath));
+        Uri uri = FileProvider.getUriForFile(this, "com.ihg.fileprovider", new File(pdfFilePath));
 
         Intent intent = new Intent(Intent.ACTION_SEND);
         intent.setType("text/plain");

--- a/ihg/src/main/java/com/wruzjan/ihg/EnterDataNewPaderewskiegoActivity.java
+++ b/ihg/src/main/java/com/wruzjan/ihg/EnterDataNewPaderewskiegoActivity.java
@@ -45,6 +45,8 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 
+import androidx.core.content.FileProvider;
+
 public class EnterDataNewPaderewskiegoActivity extends Activity {
 
     private static ArrayList<String> PRINTER_MACS = new ArrayList<String>();
@@ -848,7 +850,7 @@ public class EnterDataNewPaderewskiegoActivity extends Activity {
     }
 
     public void sendMail(View view) {
-        Uri uri = Uri.fromFile(new File(pdfFilePath));
+        Uri uri = FileProvider.getUriForFile(this, "com.ihg.fileprovider", new File(pdfFilePath));
 
         Intent i = new Intent(Intent.ACTION_SEND);
         i.setType("message/rfc822");
@@ -875,7 +877,7 @@ public class EnterDataNewPaderewskiegoActivity extends Activity {
     }
 
     public void dropbox(View view) {
-        Uri uri = Uri.fromFile(new File(pdfFilePath));
+        Uri uri = FileProvider.getUriForFile(this, "com.ihg.fileprovider", new File(pdfFilePath));
 
         Intent intent = new Intent(Intent.ACTION_SEND);
         intent.setType("text/plain");

--- a/ihg/src/main/res/xml/file_paths.xml
+++ b/ihg/src/main/res/xml/file_paths.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+
+    <external-path
+        name="ihg"
+        path="IHG/" />
+</paths>


### PR DESCRIPTION
Wrzuciłem tę PR-kę, bo w nowszych Androidach (na 6.0 emu sprawdzałem) są dodatkowe zabezpieczenia z udostępnianiem plików dla innych appek i zalecane przez Google jest używanie FileProvider. W przeciwnym wypadku nie będzie się dało udostępniać plików.