### PR TITLE
Change search address inputType to default.

### DIFF
--- a/ihg/src/main/res/layout/activity_browse_addresses.xml
+++ b/ihg/src/main/res/layout/activity_browse_addresses.xml
@@ -166,8 +166,7 @@
                 android:id="@+id/inputSearch"
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
-                android:hint="znajdź adres"
-                android:inputType="textVisiblePassword"/>
+                android:hint="znajdź adres"/>
 
             <LinearLayout android:id="@+id/list_wrapper"
                           xmlns:android="http://schemas.android.com/apk/res/android"


### PR DESCRIPTION
W wyszukiwarce adresów był ustawiony inputType "textVisiblePassword", który blokuje usuwanie znaków. Usunąłem ustawianie inputType dzięki czemu zostanie on nastawiony na domyślny text.